### PR TITLE
Fix UserSettings identity generator

### DIFF
--- a/grails-app/domain/com/thomsonreuters/lsps/transmart/UserSettings.groovy
+++ b/grails-app/domain/com/thomsonreuters/lsps/transmart/UserSettings.groovy
@@ -10,7 +10,7 @@ class UserSettings {
     static mapping = {
         version false
         table 'searchapp.search_user_settings'
-        id column: 'ID'
+        id column: 'ID', generator: 'sequence', params: [sequence: 'SEARCHAPP.HIBERNATE_SEQUENCE']
         userId column: 'USER_ID'
         name column: 'SETTING_NAME'
         value column: 'SETTING_VALUE'


### PR DESCRIPTION
UserSettings by default using hibernate_sequence which is not present in schema public (instead it present in schema SEARCHAPP). So it is required to manually specify schema prefix for sequence generator.
